### PR TITLE
Fix for "WARNING: Found negative value:" when using Get-Sparkline 

### DIFF
--- a/PSparklines.psm1
+++ b/PSparklines.psm1
@@ -544,7 +544,7 @@ function Get-Sparkline {
     }
 
     process {
-        [void] $Numbers.ForEach($ls.Add($_))
+        [void] $Numbers.ForEach({ $ls.Add($_) })
     }
 
     end {


### PR DESCRIPTION
![Get-Sparkline](https://user-images.githubusercontent.com/32566829/174941536-dec2d948-2e14-4e7c-8027-abb41946b2d4.png)

Tested on Windows 10 and 11, PowerShell 5 and PowerShell 7. Unable to Get-Sparkline without this warning. 
 

> PS F:\PowerShell\PSparklines> $ls = [System.Collections.ArrayList] @()       
> PS F:\PowerShell\PSparklines> [void] $Numbers.ForEach($ls.Add($_))
> PS F:\PowerShell\PSparklines> $ls
> PS F:\PowerShell\PSparklines> [void] $Numbers.ForEach({$ls.Add($_)})
> PS F:\PowerShell\PSparklines> $ls
> 1
> 2
> 3
> 4
> 10
